### PR TITLE
feat: add Invoice Key QR screen for LaChispaPOS integration

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -321,5 +321,10 @@
   "error_checking_currency": "Fehler beim Überprüfen von {currency}: {error}",
   
   "deep_link_login_required_title": "Anmeldung erforderlich",
-  "deep_link_login_required_message": "Sie müssen sich in Ihr LaChispa-Konto einloggen, um diese Zahlung zu verarbeiten."
+  "deep_link_login_required_message": "Sie müssen sich in Ihr LaChispa-Konto einloggen, um diese Zahlung zu verarbeiten.",
+  
+  "invoice_key_qr_title": "Rechnungsschlüssel QR",
+  "invoice_key_qr_description": "Verwenden Sie diesen QR-Code mit LaChispaPOS oder anderen Lightning-Apps, um Zahlungen zu empfangen, ohne Ihren Admin-Schlüssel preiszugeben.",
+  "copy_invoice_key": "Schlüssel kopieren",
+  "invoice_key_copied": "Rechnungsschlüssel in die Zwischenablage kopiert"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -331,5 +331,10 @@
   "error_checking_currency": "Error checking {currency}: {error}",
   
   "deep_link_login_required_title": "Login Required",
-  "deep_link_login_required_message": "You must log in to your LaChispa account to process this payment."
+  "deep_link_login_required_message": "You must log in to your LaChispa account to process this payment.",
+  
+  "invoice_key_qr_title": "Invoice Key QR",
+  "invoice_key_qr_description": "Use this QR code with LaChispaPOS or other Lightning apps to receive payments without exposing your admin key.",
+  "copy_invoice_key": "Copy Key",
+  "invoice_key_copied": "Invoice key copied to clipboard"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -328,5 +328,10 @@
   "error_checking_currency": "Error verificando {currency}: {error}",
   
   "deep_link_login_required_title": "Inicio de sesión requerido",
-  "deep_link_login_required_message": "Debes iniciar sesión en tu cuenta LaChispa para procesar este pago."
+  "deep_link_login_required_message": "Debes iniciar sesión en tu cuenta LaChispa para procesar este pago.",
+  
+  "invoice_key_qr_title": "QR de Clave de Facturación",
+  "invoice_key_qr_description": "Usa este código QR con LaChispaPOS u otras apps Lightning para recibir pagos sin exponer tu clave de administrador.",
+  "copy_invoice_key": "Copiar Clave",
+  "invoice_key_copied": "Clave de facturación copiada al portapapeles"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -321,5 +321,10 @@
   "error_checking_currency": "Erreur lors de la vérification de {currency} : {error}",
   
   "deep_link_login_required_title": "Connexion requise",
-  "deep_link_login_required_message": "Vous devez vous connecter à votre compte LaChispa pour traiter ce paiement."
+  "deep_link_login_required_message": "Vous devez vous connecter à votre compte LaChispa pour traiter ce paiement.",
+  
+  "invoice_key_qr_title": "QR de clé de facturation",
+  "invoice_key_qr_description": "Utilisez ce code QR avec LaChispaPOS ou d'autres applications Lightning pour recevoir des paiements sans exposer votre clé administrateur.",
+  "copy_invoice_key": "Copier la clé",
+  "invoice_key_copied": "Clé de facturation copiée dans le presse-papiers"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -321,5 +321,10 @@
   "error_checking_currency": "Errore nella verifica di {currency}: {error}",
   
   "deep_link_login_required_title": "Accesso richiesto",
-  "deep_link_login_required_message": "Devi accedere al tuo account LaChispa per elaborare questo pagamento."
+  "deep_link_login_required_message": "Devi accedere al tuo account LaChispa per elaborare questo pagamento.",
+  
+  "invoice_key_qr_title": "QR Chiave fattura",
+  "invoice_key_qr_description": "Usa questo codice QR con LaChispaPOS o altre app Lightning per ricevere pagamenti senza esporre la tua chiave amministratore.",
+  "copy_invoice_key": "Copia chiave",
+  "invoice_key_copied": "Chiave fattura copiata negli appunti"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -321,5 +321,10 @@
   "error_checking_currency": "Erro ao verificar {currency}: {error}",
   
   "deep_link_login_required_title": "Login Necessário",
-  "deep_link_login_required_message": "Você deve fazer login em sua conta LaChispa para processar este pagamento."
+  "deep_link_login_required_message": "Você deve fazer login em sua conta LaChispa para processar este pagamento.",
+  
+  "invoice_key_qr_title": "QR Chave da Fatura",
+  "invoice_key_qr_description": "Use este código QR com LaChispaPOS ou outros aplicativos Lightning para receber pagamentos sem expor sua chave de administrador.",
+  "copy_invoice_key": "Copiar Chave",
+  "invoice_key_copied": "Chave da fatura copiada para a área de transferência"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -321,5 +321,10 @@
   "error_checking_currency": "Ошибка при проверке {currency}: {error}",
   
   "deep_link_login_required_title": "Требуется вход в систему",
-  "deep_link_login_required_message": "Вы должны войти в свою учетную запись LaChispa для обработки этого платежа."
+  "deep_link_login_required_message": "Вы должны войти в свою учетную запись LaChispa для обработки этого платежа.",
+  
+  "invoice_key_qr_title": "QR Ключ счета",
+  "invoice_key_qr_description": "Используйте этот QR-код с LaChispaPOS или другими приложениями Lightning для получения платежей без раскрытия ключа администратора.",
+  "copy_invoice_key": "Копировать ключ",
+  "invoice_key_copied": "Ключ счета скопирован в буфер обмена"
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1697,6 +1697,30 @@ abstract class AppLocalizations {
   /// In es, this message translates to:
   /// **'Debes iniciar sesión en tu cuenta LaChispa para procesar este pago.'**
   String get deep_link_login_required_message;
+
+  /// No description provided for @invoice_key_qr_title.
+  ///
+  /// In es, this message translates to:
+  /// **'QR de Clave de Facturación'**
+  String get invoice_key_qr_title;
+
+  /// No description provided for @invoice_key_qr_description.
+  ///
+  /// In es, this message translates to:
+  /// **'Usa este código QR con LaChispaPOS u otras apps Lightning para recibir pagos sin exponer tu clave de administrador.'**
+  String get invoice_key_qr_description;
+
+  /// No description provided for @copy_invoice_key.
+  ///
+  /// In es, this message translates to:
+  /// **'Copiar Clave'**
+  String get copy_invoice_key;
+
+  /// No description provided for @invoice_key_copied.
+  ///
+  /// In es, this message translates to:
+  /// **'Clave de facturación copiada al portapapeles'**
+  String get invoice_key_copied;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -883,4 +883,18 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get deep_link_login_required_message =>
       'Sie müssen sich in Ihr LaChispa-Konto einloggen, um diese Zahlung zu verarbeiten.';
+
+  @override
+  String get invoice_key_qr_title => 'Rechnungsschlüssel QR';
+
+  @override
+  String get invoice_key_qr_description =>
+      'Verwenden Sie diesen QR-Code mit LaChispaPOS oder anderen Lightning-Apps, um Zahlungen zu empfangen, ohne Ihren Admin-Schlüssel preiszugeben.';
+
+  @override
+  String get copy_invoice_key => 'Schlüssel kopieren';
+
+  @override
+  String get invoice_key_copied =>
+      'Rechnungsschlüssel in die Zwischenablage kopiert';
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -862,4 +862,17 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get deep_link_login_required_message =>
       'You must log in to your LaChispa account to process this payment.';
+
+  @override
+  String get invoice_key_qr_title => 'Invoice Key QR';
+
+  @override
+  String get invoice_key_qr_description =>
+      'Use this QR code with LaChispaPOS or other Lightning apps to receive payments without exposing your admin key.';
+
+  @override
+  String get copy_invoice_key => 'Copy Key';
+
+  @override
+  String get invoice_key_copied => 'Invoice key copied to clipboard';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -871,4 +871,18 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get deep_link_login_required_message =>
       'Debes iniciar sesión en tu cuenta LaChispa para procesar este pago.';
+
+  @override
+  String get invoice_key_qr_title => 'QR de Clave de Facturación';
+
+  @override
+  String get invoice_key_qr_description =>
+      'Usa este código QR con LaChispaPOS u otras apps Lightning para recibir pagos sin exponer tu clave de administrador.';
+
+  @override
+  String get copy_invoice_key => 'Copiar Clave';
+
+  @override
+  String get invoice_key_copied =>
+      'Clave de facturación copiada al portapapeles';
 }

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -891,4 +891,18 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get deep_link_login_required_message =>
       'Vous devez vous connecter à votre compte LaChispa pour traiter ce paiement.';
+
+  @override
+  String get invoice_key_qr_title => 'QR de clé de facturation';
+
+  @override
+  String get invoice_key_qr_description =>
+      'Utilisez ce code QR avec LaChispaPOS ou d\'autres applications Lightning pour recevoir des paiements sans exposer votre clé administrateur.';
+
+  @override
+  String get copy_invoice_key => 'Copier la clé';
+
+  @override
+  String get invoice_key_copied =>
+      'Clé de facturation copiée dans le presse-papiers';
 }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -885,4 +885,17 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get deep_link_login_required_message =>
       'Devi accedere al tuo account LaChispa per elaborare questo pagamento.';
+
+  @override
+  String get invoice_key_qr_title => 'QR Chiave fattura';
+
+  @override
+  String get invoice_key_qr_description =>
+      'Usa questo codice QR con LaChispaPOS o altre app Lightning per ricevere pagamenti senza esporre la tua chiave amministratore.';
+
+  @override
+  String get copy_invoice_key => 'Copia chiave';
+
+  @override
+  String get invoice_key_copied => 'Chiave fattura copiata negli appunti';
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -870,4 +870,18 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get deep_link_login_required_message =>
       'Você deve fazer login em sua conta LaChispa para processar este pagamento.';
+
+  @override
+  String get invoice_key_qr_title => 'QR Chave da Fatura';
+
+  @override
+  String get invoice_key_qr_description =>
+      'Use este código QR com LaChispaPOS ou outros aplicativos Lightning para receber pagamentos sem expor sua chave de administrador.';
+
+  @override
+  String get copy_invoice_key => 'Copiar Chave';
+
+  @override
+  String get invoice_key_copied =>
+      'Chave da fatura copiada para a área de transferência';
 }

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -865,4 +865,17 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get deep_link_login_required_message =>
       'Вы должны войти в свою учетную запись LaChispa для обработки этого платежа.';
+
+  @override
+  String get invoice_key_qr_title => 'QR Ключ счета';
+
+  @override
+  String get invoice_key_qr_description =>
+      'Используйте этот QR-код с LaChispaPOS или другими приложениями Lightning для получения платежей без раскрытия ключа администратора.';
+
+  @override
+  String get copy_invoice_key => 'Копировать ключ';
+
+  @override
+  String get invoice_key_copied => 'Ключ счета скопирован в буфер обмена';
 }

--- a/lib/models/wallet_info.dart
+++ b/lib/models/wallet_info.dart
@@ -4,6 +4,7 @@ class WalletInfo {
   final String name;
   final String adminKey;
   final String inKey;
+  final String readKey;
   final int balanceMsat;
 
   WalletInfo({
@@ -11,6 +12,7 @@ class WalletInfo {
     required this.name,
     required this.adminKey,
     required this.inKey,
+    this.readKey = '',
     required this.balanceMsat,
   });
 
@@ -23,6 +25,7 @@ class WalletInfo {
       name: json['name'] as String,
       adminKey: json['adminkey'] ?? json['admin_key'] ?? json['adminKey'] ?? '',
       inKey: json['inkey'] ?? json['in_key'] ?? json['inKey'] ?? '',
+      readKey: json['readkey'] ?? json['read_key'] ?? json['readKey'] ?? '',
       balanceMsat: json['balance_msat'] ?? json['balance'] ?? 0,
     );
   }
@@ -33,6 +36,7 @@ class WalletInfo {
       'name': name,
       'adminkey': adminKey,
       'inkey': inKey,
+      'readkey': readKey,
       'balance_msat': balanceMsat,
     };
   }
@@ -83,9 +87,9 @@ class WalletBalance {
 
 class WalletException implements Exception {
   final String message;
-  
+
   WalletException(this.message);
-  
+
   @override
   String toString() => 'WalletException: $message';
 }

--- a/lib/screens/17settings_screen.dart
+++ b/lib/screens/17settings_screen.dart
@@ -6,6 +6,7 @@ import '../l10n/generated/app_localizations.dart';
 import '7ln_address_screen.dart';
 import '16currency_settings_screen.dart';
 import '18language_selection_screen.dart';
+import '19invoice_key_screen.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -38,17 +39,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
             children: [
               // Header with back button
               _buildHeader(),
-              
+
               // Settings list
               Expanded(
                 child: ListView(
-                  padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
                   children: [
                     // Lightning Address
                     _buildSettingsItem(
                       icon: Icons.alternate_email,
                       iconColor: const Color(0xFF4C63F7),
-                      title: AppLocalizations.of(context)!.lightning_address_title,
+                      title:
+                          AppLocalizations.of(context)!.lightning_address_title,
                       onTap: () {
                         Navigator.push(
                           context,
@@ -58,43 +61,66 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         );
                       },
                     ),
-                    
+
                     const SizedBox(height: 12),
-                    
+
+                    // Invoice Key QR
+                    _buildSettingsItem(
+                      icon: Icons.qr_code,
+                      iconColor: const Color(0xFF4C63F7),
+                      title: AppLocalizations.of(context)!.invoice_key_qr_title,
+                      subtitle: 'Show QR for other apps',
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const InvoiceKeyScreen(),
+                          ),
+                        );
+                      },
+                    ),
+
+                    const SizedBox(height: 12),
+
                     // Currency Settings
                     Consumer<CurrencySettingsProvider>(
                       builder: (context, currencyProvider, child) {
                         return _buildSettingsItem(
                           icon: Icons.attach_money,
                           iconColor: const Color(0xFF4C63F7),
-                          title: AppLocalizations.of(context)!.currency_settings_title,
-                          subtitle: '${currencyProvider.availableCurrencies.length} currencies',
+                          title: AppLocalizations.of(context)!
+                              .currency_settings_title,
+                          subtitle:
+                              '${currencyProvider.availableCurrencies.length} currencies',
                           onTap: () {
                             Navigator.push(
                               context,
                               MaterialPageRoute(
-                                builder: (context) => const CurrencySettingsScreen(),
+                                builder: (context) =>
+                                    const CurrencySettingsScreen(),
                               ),
                             );
                           },
                         );
                       },
                     ),
-                    
+
                     const SizedBox(height: 12),
-                    
+
                     // Language Settings
                     Consumer<LanguageProvider>(
                       builder: (context, languageProvider, child) {
                         return _buildSettingsItem(
                           icon: Icons.language,
                           iconColor: const Color(0xFF4C63F7),
-                          title: AppLocalizations.of(context)!.language_selector_title,
+                          title: AppLocalizations.of(context)!
+                              .language_selector_title,
                           subtitle: languageProvider.getCurrentLanguageName(),
                           onTap: () => Navigator.push(
                             context,
                             MaterialPageRoute(
-                              builder: (context) => const LanguageSelectionScreen(),
+                              builder: (context) =>
+                                  const LanguageSelectionScreen(),
                             ),
                           ),
                         );
@@ -219,5 +245,4 @@ class _SettingsScreenState extends State<SettingsScreen> {
       ),
     );
   }
-
 }

--- a/lib/screens/19invoice_key_screen.dart
+++ b/lib/screens/19invoice_key_screen.dart
@@ -1,0 +1,284 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import '../providers/wallet_provider.dart';
+import '../l10n/generated/app_localizations.dart';
+
+class InvoiceKeyScreen extends StatelessWidget {
+  const InvoiceKeyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        width: double.infinity,
+        height: double.infinity,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [
+              Color(0xFF0F1419),
+              Color(0xFF1A1D47),
+              Color(0xFF2D3FE7),
+            ],
+            stops: [0.0, 0.5, 1.0],
+          ),
+        ),
+        child: SafeArea(
+          child: Column(
+            children: [
+              _buildHeader(context),
+              Expanded(
+                child: _buildContent(context),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: () => Navigator.pop(context),
+            child: Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: const Icon(
+                Icons.arrow_back,
+                color: Colors.white,
+                size: 24,
+              ),
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Text(
+              AppLocalizations.of(context)!.invoice_key_qr_title,
+              style: const TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 20,
+                fontWeight: FontWeight.w600,
+                color: Colors.white,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    return Consumer<WalletProvider>(
+      builder: (context, walletProvider, child) {
+        final wallet = walletProvider.primaryWallet;
+        final inKey = wallet?.inKey ?? '';
+
+        if (wallet == null || inKey.isEmpty) {
+          return Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(
+                    Icons.warning_amber_rounded,
+                    color: Colors.orange,
+                    size: 64,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'No wallet found',
+                    style: TextStyle(
+                      fontFamily: 'Inter',
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.white.withValues(alpha: 0.9),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Please create a wallet first',
+                    style: TextStyle(
+                      fontFamily: 'Inter',
+                      fontSize: 14,
+                      color: Colors.white.withValues(alpha: 0.6),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        return SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Column(
+            children: [
+              const SizedBox(height: 20),
+              _buildQRCode(inKey),
+              const SizedBox(height: 24),
+              _buildKeyInfo(context, inKey),
+              const SizedBox(height: 24),
+              _buildCopyButton(context, inKey),
+              const SizedBox(height: 24),
+              _buildWarning(context),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildQRCode(String inKey) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.3),
+            blurRadius: 20,
+            offset: const Offset(0, 10),
+          ),
+        ],
+      ),
+      child: QrImageView(
+        data: inKey,
+        version: QrVersions.auto,
+        size: 220.0,
+        backgroundColor: Colors.white,
+        errorCorrectionLevel: QrErrorCorrectLevel.H,
+      ),
+    );
+  }
+
+  Widget _buildKeyInfo(BuildContext context, String inKey) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: Colors.white.withValues(alpha: 0.1),
+          width: 1,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            AppLocalizations.of(context)!.invoice_key_label,
+            style: TextStyle(
+              fontFamily: 'Inter',
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+              color: Colors.white.withValues(alpha: 0.6),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            inKey,
+            style: const TextStyle(
+              fontFamily: 'monospace',
+              fontSize: 12,
+              color: Colors.white,
+            ),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCopyButton(BuildContext context, String inKey) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton.icon(
+        onPressed: () => _copyToClipboard(context, inKey),
+        icon: const Icon(Icons.copy, size: 20),
+        label: Text(
+          AppLocalizations.of(context)!.copy_invoice_key,
+          style: const TextStyle(
+            fontFamily: 'Inter',
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        style: ElevatedButton.styleFrom(
+          backgroundColor: const Color(0xFF4C63F7),
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWarning(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.amber.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: Colors.amber.withValues(alpha: 0.3),
+          width: 1,
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(
+            Icons.info_outline,
+            color: Colors.amber,
+            size: 24,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              AppLocalizations.of(context)!.invoice_key_qr_description,
+              style: TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 14,
+                color: Colors.white.withValues(alpha: 0.8),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _copyToClipboard(BuildContext context, String text) {
+    Clipboard.setData(ClipboardData(text: text));
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          AppLocalizations.of(context)!.invoice_key_copied,
+          style: const TextStyle(fontFamily: 'Inter'),
+        ),
+        backgroundColor: const Color(0xFF4C63F7),
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10),
+        ),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a new **Invoice Key QR** feature that allows business owners to share their invoice key (inkey) via QR code for use with **LaChispaPOS** to receive payments without exposing the admin key.

## Changes

### New Files
- `lib/screens/19invoice_key_screen.dart` - New screen displaying QR code with invoice key

### Modified Files
- `lib/models/wallet_info.dart` - Added `readKey` field
- `lib/screens/17settings_screen.dart` - Added "Invoice Key QR" option
- `lib/l10n/app_*.arb` - Updated all 7 language files with new translations

## How it Works

1. Business owner: Settings → Invoice Key QR
2. Shows QR code with invoice key
3. Employee (using LaChispaPOS): Scans the QR
4. Employee can create invoices to receive payments

## Security Considerations

- The **Invoice Key** only allows creating invoices (limited write access)
- Does NOT allow access to funds, sending payments, or sensitive operations
- Ideal for scenarios where receiving payments is needed without security risks

---

**Closes:** #68