### PR TITLE
fix: use readKey for public QR and localize empty-state messages

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -325,6 +325,24 @@
   
   "invoice_key_qr_title": "Rechnungsschlüssel QR",
   "invoice_key_qr_description": "Verwenden Sie diesen QR-Code mit LaChispaPOS oder anderen Lightning-Apps, um Zahlungen zu empfangen, ohne Ihren Admin-Schlüssel preiszugeben.",
+  "invoice_key_qr_subtitle": "QR für andere Apps anzeigen",
   "copy_invoice_key": "Schlüssel kopieren",
-  "invoice_key_copied": "Rechnungsschlüssel in die Zwischenablage kopiert"
+  "invoice_key_copied": "Rechnungsschlüssel in die Zwischenablage kopiert",
+  "invoice_key_unavailable_title": "Keine Brieftasche gefunden",
+  "invoice_key_unavailable_subtitle": "Bitte erstellen Sie zuerst eine Brieftasche",
+  "@invoice_key_unavailable_title": {
+    "description": "Titel wenn keine Brieftasche verfügbar ist"
+  },
+  "@invoice_key_unavailable_subtitle": {
+    "description": "Untertitel wenn keine Brieftasche verfügbar ist"
+  },
+  "currency_count": "{count, plural, =1{1 Währung} other{{count} Währungen}}",
+  "@currency_count": {
+    "description": "Anzahl verfügbarer Währungen",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -335,6 +335,24 @@
   
   "invoice_key_qr_title": "Invoice Key QR",
   "invoice_key_qr_description": "Use this QR code with LaChispaPOS or other Lightning apps to receive payments without exposing your admin key.",
+  "invoice_key_qr_subtitle": "Show QR for other apps",
   "copy_invoice_key": "Copy Key",
-  "invoice_key_copied": "Invoice key copied to clipboard"
+  "invoice_key_copied": "Invoice key copied to clipboard",
+  "invoice_key_unavailable_title": "No wallet found",
+  "invoice_key_unavailable_subtitle": "Please create a wallet first",
+  "@invoice_key_unavailable_title": {
+    "description": "Title shown when no wallet is available"
+  },
+  "@invoice_key_unavailable_subtitle": {
+    "description": "Subtitle shown when no wallet is available"
+  },
+  "currency_count": "{count, plural, =1{1 currency} other{{count} currencies}}",
+  "@currency_count": {
+    "description": "Number of available currencies",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -332,6 +332,24 @@
   
   "invoice_key_qr_title": "QR de Clave de Facturación",
   "invoice_key_qr_description": "Usa este código QR con LaChispaPOS u otras apps Lightning para recibir pagos sin exponer tu clave de administrador.",
+  "invoice_key_qr_subtitle": "Mostrar QR para otras apps",
   "copy_invoice_key": "Copiar Clave",
-  "invoice_key_copied": "Clave de facturación copiada al portapapeles"
+  "invoice_key_copied": "Clave de facturación copiada al portapapeles",
+  "invoice_key_unavailable_title": "Billetera no encontrada",
+  "invoice_key_unavailable_subtitle": "Por favor crea una billetera primero",
+  "@invoice_key_unavailable_title": {
+    "description": "Título cuando no hay billetera disponible"
+  },
+  "@invoice_key_unavailable_subtitle": {
+    "description": "Subtítulo cuando no hay billetera disponible"
+  },
+  "currency_count": "{count, plural, =1{1 moneda} other{{count} monedas}}",
+  "@currency_count": {
+    "description": "Cantidad de monedas disponibles",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -325,6 +325,24 @@
   
   "invoice_key_qr_title": "QR de clé de facturation",
   "invoice_key_qr_description": "Utilisez ce code QR avec LaChispaPOS ou d'autres applications Lightning pour recevoir des paiements sans exposer votre clé administrateur.",
+  "invoice_key_qr_subtitle": "Afficher le QR pour d'autres apps",
   "copy_invoice_key": "Copier la clé",
-  "invoice_key_copied": "Clé de facturation copiée dans le presse-papiers"
+  "invoice_key_copied": "Clé de facturation copiée dans le presse-papiers",
+  "invoice_key_unavailable_title": "Portefeuille non trouvé",
+  "invoice_key_unavailable_subtitle": "Veuillez d'abord créer un portefeuille",
+  "@invoice_key_unavailable_title": {
+    "description": "Titre quand aucun portefeuille n'est disponible"
+  },
+  "@invoice_key_unavailable_subtitle": {
+    "description": "Sous-titre quand aucun portefeuille n'est disponible"
+  },
+  "currency_count": "{count, plural, =1{1 devise} other{{count} devises}}",
+  "@currency_count": {
+    "description": "Nombre de devises disponibles",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -325,6 +325,24 @@
   
   "invoice_key_qr_title": "QR Chiave fattura",
   "invoice_key_qr_description": "Usa questo codice QR con LaChispaPOS o altre app Lightning per ricevere pagamenti senza esporre la tua chiave amministratore.",
+  "invoice_key_qr_subtitle": "Mostra QR per altre app",
   "copy_invoice_key": "Copia chiave",
-  "invoice_key_copied": "Chiave fattura copiata negli appunti"
+  "invoice_key_copied": "Chiave fattura copiata negli appunti",
+  "invoice_key_unavailable_title": "Portafoglio non trovato",
+  "invoice_key_unavailable_subtitle": "Crea prima un portafoglio",
+  "@invoice_key_unavailable_title": {
+    "description": "Titolo quando nessun portafoglio è disponibile"
+  },
+  "@invoice_key_unavailable_subtitle": {
+    "description": "Sottotitolo quando nessun portafoglio è disponibile"
+  },
+  "currency_count": "{count, plural, =1{1 valuta} other{{count} valute}}",
+  "@currency_count": {
+    "description": "Numero di valute disponibili",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -325,6 +325,24 @@
   
   "invoice_key_qr_title": "QR Chave da Fatura",
   "invoice_key_qr_description": "Use este código QR com LaChispaPOS ou outros aplicativos Lightning para receber pagamentos sem expor sua chave de administrador.",
+  "invoice_key_qr_subtitle": "Mostrar QR para outros apps",
   "copy_invoice_key": "Copiar Chave",
-  "invoice_key_copied": "Chave da fatura copiada para a área de transferência"
+  "invoice_key_copied": "Chave da fatura copiada para a área de transferência",
+  "invoice_key_unavailable_title": "Carteira não encontrada",
+  "invoice_key_unavailable_subtitle": "Por favor crie uma carteira primeiro",
+  "@invoice_key_unavailable_title": {
+    "description": "Título quando nenhuma carteira está disponível"
+  },
+  "@invoice_key_unavailable_subtitle": {
+    "description": "Subtítulo quando nenhuma carteira está disponível"
+  },
+  "currency_count": "{count, plural, =1{1 moeda} other{{count} moedas}}",
+  "@currency_count": {
+    "description": "Número de moedas disponíveis",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -325,6 +325,24 @@
   
   "invoice_key_qr_title": "QR Ключ счета",
   "invoice_key_qr_description": "Используйте этот QR-код с LaChispaPOS или другими приложениями Lightning для получения платежей без раскрытия ключа администратора.",
+  "invoice_key_qr_subtitle": "Показать QR для других приложений",
   "copy_invoice_key": "Копировать ключ",
-  "invoice_key_copied": "Ключ счета скопирован в буфер обмена"
+  "invoice_key_copied": "Ключ счета скопирован в буфер обмена",
+  "invoice_key_unavailable_title": "Кошелек не найден",
+  "invoice_key_unavailable_subtitle": "Пожалуйста, сначала создайте кошелек",
+  "@invoice_key_unavailable_title": {
+    "description": "Заголовок когда кошелек недоступен"
+  },
+  "@invoice_key_unavailable_subtitle": {
+    "description": "Подзаголовок когда кошелек недоступен"
+  },
+  "currency_count": "{count, plural, =1{1 валюта} few{{count} валюты} other{{count} валют}}",
+  "@currency_count": {
+    "description": "Количество доступных валют",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1710,6 +1710,12 @@ abstract class AppLocalizations {
   /// **'Usa este código QR con LaChispaPOS u otras apps Lightning para recibir pagos sin exponer tu clave de administrador.'**
   String get invoice_key_qr_description;
 
+  /// No description provided for @invoice_key_qr_subtitle.
+  ///
+  /// In es, this message translates to:
+  /// **'Mostrar QR para otras apps'**
+  String get invoice_key_qr_subtitle;
+
   /// No description provided for @copy_invoice_key.
   ///
   /// In es, this message translates to:
@@ -1721,6 +1727,24 @@ abstract class AppLocalizations {
   /// In es, this message translates to:
   /// **'Clave de facturación copiada al portapapeles'**
   String get invoice_key_copied;
+
+  /// Título cuando no hay billetera disponible
+  ///
+  /// In es, this message translates to:
+  /// **'Billetera no encontrada'**
+  String get invoice_key_unavailable_title;
+
+  /// Subtítulo cuando no hay billetera disponible
+  ///
+  /// In es, this message translates to:
+  /// **'Por favor crea una billetera primero'**
+  String get invoice_key_unavailable_subtitle;
+
+  /// Cantidad de monedas disponibles
+  ///
+  /// In es, this message translates to:
+  /// **'{count, plural, =1{1 moneda} other{{count} monedas}}'**
+  String currency_count(int count);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -892,9 +892,30 @@ class AppLocalizationsDe extends AppLocalizations {
       'Verwenden Sie diesen QR-Code mit LaChispaPOS oder anderen Lightning-Apps, um Zahlungen zu empfangen, ohne Ihren Admin-Schlüssel preiszugeben.';
 
   @override
+  String get invoice_key_qr_subtitle => 'QR für andere Apps anzeigen';
+
+  @override
   String get copy_invoice_key => 'Schlüssel kopieren';
 
   @override
   String get invoice_key_copied =>
       'Rechnungsschlüssel in die Zwischenablage kopiert';
+
+  @override
+  String get invoice_key_unavailable_title => 'Keine Brieftasche gefunden';
+
+  @override
+  String get invoice_key_unavailable_subtitle =>
+      'Bitte erstellen Sie zuerst eine Brieftasche';
+
+  @override
+  String currency_count(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Währungen',
+      one: '1 Währung',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -871,8 +871,28 @@ class AppLocalizationsEn extends AppLocalizations {
       'Use this QR code with LaChispaPOS or other Lightning apps to receive payments without exposing your admin key.';
 
   @override
+  String get invoice_key_qr_subtitle => 'Show QR for other apps';
+
+  @override
   String get copy_invoice_key => 'Copy Key';
 
   @override
   String get invoice_key_copied => 'Invoice key copied to clipboard';
+
+  @override
+  String get invoice_key_unavailable_title => 'No wallet found';
+
+  @override
+  String get invoice_key_unavailable_subtitle => 'Please create a wallet first';
+
+  @override
+  String currency_count(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count currencies',
+      one: '1 currency',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -880,9 +880,30 @@ class AppLocalizationsEs extends AppLocalizations {
       'Usa este código QR con LaChispaPOS u otras apps Lightning para recibir pagos sin exponer tu clave de administrador.';
 
   @override
+  String get invoice_key_qr_subtitle => 'Mostrar QR para otras apps';
+
+  @override
   String get copy_invoice_key => 'Copiar Clave';
 
   @override
   String get invoice_key_copied =>
       'Clave de facturación copiada al portapapeles';
+
+  @override
+  String get invoice_key_unavailable_title => 'Billetera no encontrada';
+
+  @override
+  String get invoice_key_unavailable_subtitle =>
+      'Por favor crea una billetera primero';
+
+  @override
+  String currency_count(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count monedas',
+      one: '1 moneda',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -900,9 +900,30 @@ class AppLocalizationsFr extends AppLocalizations {
       'Utilisez ce code QR avec LaChispaPOS ou d\'autres applications Lightning pour recevoir des paiements sans exposer votre clé administrateur.';
 
   @override
+  String get invoice_key_qr_subtitle => 'Afficher le QR pour d\'autres apps';
+
+  @override
   String get copy_invoice_key => 'Copier la clé';
 
   @override
   String get invoice_key_copied =>
       'Clé de facturation copiée dans le presse-papiers';
+
+  @override
+  String get invoice_key_unavailable_title => 'Portefeuille non trouvé';
+
+  @override
+  String get invoice_key_unavailable_subtitle =>
+      'Veuillez d\'abord créer un portefeuille';
+
+  @override
+  String currency_count(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count devises',
+      one: '1 devise',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -894,8 +894,28 @@ class AppLocalizationsIt extends AppLocalizations {
       'Usa questo codice QR con LaChispaPOS o altre app Lightning per ricevere pagamenti senza esporre la tua chiave amministratore.';
 
   @override
+  String get invoice_key_qr_subtitle => 'Mostra QR per altre app';
+
+  @override
   String get copy_invoice_key => 'Copia chiave';
 
   @override
   String get invoice_key_copied => 'Chiave fattura copiata negli appunti';
+
+  @override
+  String get invoice_key_unavailable_title => 'Portafoglio non trovato';
+
+  @override
+  String get invoice_key_unavailable_subtitle => 'Crea prima un portafoglio';
+
+  @override
+  String currency_count(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count valute',
+      one: '1 valuta',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -879,9 +879,30 @@ class AppLocalizationsPt extends AppLocalizations {
       'Use este código QR com LaChispaPOS ou outros aplicativos Lightning para receber pagamentos sem expor sua chave de administrador.';
 
   @override
+  String get invoice_key_qr_subtitle => 'Mostrar QR para outros apps';
+
+  @override
   String get copy_invoice_key => 'Copiar Chave';
 
   @override
   String get invoice_key_copied =>
       'Chave da fatura copiada para a área de transferência';
+
+  @override
+  String get invoice_key_unavailable_title => 'Carteira não encontrada';
+
+  @override
+  String get invoice_key_unavailable_subtitle =>
+      'Por favor crie uma carteira primeiro';
+
+  @override
+  String currency_count(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count moedas',
+      one: '1 moeda',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -874,8 +874,30 @@ class AppLocalizationsRu extends AppLocalizations {
       'Используйте этот QR-код с LaChispaPOS или другими приложениями Lightning для получения платежей без раскрытия ключа администратора.';
 
   @override
+  String get invoice_key_qr_subtitle => 'Показать QR для других приложений';
+
+  @override
   String get copy_invoice_key => 'Копировать ключ';
 
   @override
   String get invoice_key_copied => 'Ключ счета скопирован в буфер обмена';
+
+  @override
+  String get invoice_key_unavailable_title => 'Кошелек не найден';
+
+  @override
+  String get invoice_key_unavailable_subtitle =>
+      'Пожалуйста, сначала создайте кошелек';
+
+  @override
+  String currency_count(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count валют',
+      few: '$count валюты',
+      one: '1 валюта',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/screens/17settings_screen.dart
+++ b/lib/screens/17settings_screen.dart
@@ -69,7 +69,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       icon: Icons.qr_code,
                       iconColor: const Color(0xFF4C63F7),
                       title: AppLocalizations.of(context)!.invoice_key_qr_title,
-                      subtitle: 'Show QR for other apps',
+                      subtitle:
+                          AppLocalizations.of(context)!.invoice_key_qr_subtitle,
                       onTap: () {
                         Navigator.push(
                           context,
@@ -90,8 +91,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           iconColor: const Color(0xFF4C63F7),
                           title: AppLocalizations.of(context)!
                               .currency_settings_title,
-                          subtitle:
-                              '${currencyProvider.availableCurrencies.length} currencies',
+                          subtitle: AppLocalizations.of(context)!
+                              .currency_count(
+                                  currencyProvider.availableCurrencies.length),
                           onTap: () {
                             Navigator.push(
                               context,

--- a/lib/screens/19invoice_key_screen.dart
+++ b/lib/screens/19invoice_key_screen.dart
@@ -81,9 +81,11 @@ class InvoiceKeyScreen extends StatelessWidget {
     return Consumer<WalletProvider>(
       builder: (context, walletProvider, child) {
         final wallet = walletProvider.primaryWallet;
-        final inKey = wallet?.inKey ?? '';
+        final invoiceKey = (wallet?.readKey ?? '').isEmpty
+            ? (wallet?.inKey ?? '')
+            : (wallet?.readKey ?? '');
 
-        if (wallet == null || inKey.isEmpty) {
+        if (wallet == null || invoiceKey.isEmpty) {
           return Center(
             child: Padding(
               padding: const EdgeInsets.all(24),
@@ -97,7 +99,7 @@ class InvoiceKeyScreen extends StatelessWidget {
                   ),
                   const SizedBox(height: 16),
                   Text(
-                    'No wallet found',
+                    AppLocalizations.of(context)!.invoice_key_unavailable_title,
                     style: TextStyle(
                       fontFamily: 'Inter',
                       fontSize: 18,
@@ -107,7 +109,8 @@ class InvoiceKeyScreen extends StatelessWidget {
                   ),
                   const SizedBox(height: 8),
                   Text(
-                    'Please create a wallet first',
+                    AppLocalizations.of(context)!
+                        .invoice_key_unavailable_subtitle,
                     style: TextStyle(
                       fontFamily: 'Inter',
                       fontSize: 14,
@@ -125,11 +128,11 @@ class InvoiceKeyScreen extends StatelessWidget {
           child: Column(
             children: [
               const SizedBox(height: 20),
-              _buildQRCode(inKey),
+              _buildQRCode(invoiceKey),
               const SizedBox(height: 24),
-              _buildKeyInfo(context, inKey),
+              _buildKeyInfo(context, invoiceKey),
               const SizedBox(height: 24),
-              _buildCopyButton(context, inKey),
+              _buildCopyButton(context, invoiceKey),
               const SizedBox(height: 24),
               _buildWarning(context),
             ],


### PR DESCRIPTION
- Use readKey with fallback to inKey for invoice QR (least privilege)
- Localize empty state messages in invoice key screen
- Localize settings screen hardcoded subtitles
- Add plurals for currency count in all 7 languages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added localized messages for invoice key QR workflow and wallet unavailability scenarios across German, English, Spanish, French, Italian, Portuguese, and Russian
  * Improved currency count display with proper pluralization support in settings
  * Enhanced user experience with fully translated empty-state feedback messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->